### PR TITLE
Registration page

### DIFF
--- a/ProjectSourceCode/src/views/pages/register.hbs
+++ b/ProjectSourceCode/src/views/pages/register.hbs
@@ -1,0 +1,12 @@
+<form action="/register" method="POST">
+  <div class="mb-3">
+    <label for="exampleInputUsername" class="form-label">Username</label>
+    <input name="username" type="text" class="form-control" id="exampleInputUsername">
+    <label for="exampleInputPassword" class="form-label">Password</label>
+    <input name="password" type="password" class="form-control" id="exampleInputPassword">
+    <label for="exampleInputSpotify" class="form-label">Spotify Account Username</label>
+    <input name="spotifyusername" type="text" class="form-control" id="exampleInputSpotify">
+  </div>
+  <button type="submit" class="btn btn-primary">Register</button>
+</form>
+<p>Already have an account? <a href="/login">Login</a></p>

--- a/ProjectSourceCode/src/views/partitals/footer.hbs
+++ b/ProjectSourceCode/src/views/partitals/footer.hbs
@@ -1,0 +1,9 @@
+<footer class="text-center text-muted w-100 mt-auto fixed-bottom">
+    <!-- TODO: Add the <script><script /> tag to include bootstrap javascript -->
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <p>
+        &copy; Copyright 2024 : CSCI 3308 - Lab 8 Web Services
+    </p>
+</footer>
+</body>
+</html>

--- a/ProjectSourceCode/src/views/partitals/header.hbs
+++ b/ProjectSourceCode/src/views/partitals/header.hbs
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en" class="h-100">
+<head>
+  <meta charset="UTF-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1, shrink-to-fit=no"
+  />
+  <meta name="description" content="" />
+
+  <!-- TODO: Include the `title` partial here -->
+  {{> title }}
+
+      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+
+</head>
+<body class="h-100 d-flex flex-column">

--- a/ProjectSourceCode/src/views/partitals/message.hbs
+++ b/ProjectSourceCode/src/views/partitals/message.hbs
@@ -1,0 +1,5 @@
+{{#if message}}
+  <div class="alert alert-{{#if error}}danger{{else}}success{{/if}}" role="alert">
+    {{ message }}
+  </div>
+{{/if}}


### PR DESCRIPTION
This pull request adds appropriate handlebar templates into repository for use to make pages. Primarily, it adds in the registration template which is a form to allow for registering new users.

Templates Added:
- header.hbs
- footer.hbs
- message.hbs
- register.hbs

May have to reopen issue 11 in the future if we also need to collect the User's spotify password.